### PR TITLE
more tinkering

### DIFF
--- a/cat2-xs.tex
+++ b/cat2-xs.tex
@@ -167,17 +167,19 @@ The notion of crossed module, generalizing the notion of a G-module,
 was introduced by Whitehead \cite{whitehead-II} in the course of his studies 
 on the algebraic structure of the second relative homotopy group.
 
-%\vspace*{4mm}
-%\textcolor{red}
-%{[It is confusing having a crossed module $C \to G$ 
-%and a cat$^1$-group $G \Rightarrow R$. 
-%So changing all the $C \to G$ to $S \to R$, as in XMod. 
-%But now $s \in S$ so best not to use $s,t$ as source and target maps 
-%in the cat$^1$-group, hence changing to tail and head maps $t,h$. 
-%(I've resisted the temptation to change left actions into right actions!) 
-%If you are not happy with this, the commit can be ditched.]
-%} 
-%\vspace*{4mm}
+\vspace*{4mm}
+\textcolor{red}
+{[It is confusing having a crossed module $C \to G$ 
+and a cat$^1$-group $G \Rightarrow R$. 
+So changing all the $C \to G$ to $S \to R$, as in XMod. 
+But now $s \in S$ so best not to use $s,t$ as source and target maps 
+in the cat$^1$-group, hence changing to tail and head maps $t,h$. 
+(I've resisted the temptation to change left actions into right actions!) 
+If you are not happy with this, the commit can be ditched.]
+} 
+\textcolor{blue}
+{[okay however you like]} 
+\vspace*{4mm}
 
 A \emph{crossed module} consists of a group homomorphism 
 $\partial : S \rightarrow R$, endowed with a left action $R$ on $S$ 

--- a/cat2-xs.tex
+++ b/cat2-xs.tex
@@ -76,25 +76,54 @@ Functions for computing with these structures have been developed in
 the package \XMod\ written using the \GAP\ computational discrete algebra 
 programming language.
 This paper includes details of the algorithms used. 
-It contains tables listing the $1,086$ \textcolor{red}{(?)} 
+It contains tables listing the $1,065$ \textcolor{red}{(?)} 
 isomorphism classes of cat$^2$-groups on groups of order at most $30$. 
 
 
 \end{abstract}
 
-\noindent{\bf Key Words:} cat$^2$-group, crossed square, \GAP\, \XMod\ 
+\noindent{\bf Key Words:} cat$^2$-group, crossed square, \GAP, \XMod\ 
 \\ {\bf Classification:} 18D35, 18G50, .
 
 %---------------------------------------------------------------------------% 
 \section{Introduction}
 
 \textcolor{red}
-{[This is just a first attempt.]} 
+{This is just a first attempt. 
+At present the following papers, contained in the bibliography, 
+are not yet cited. 
+As they have been added to the bibliography, 
+there may have been some intention to refer to them. 
+We need to consider each in turn.} 
+\textcolor{red}
+{\begin{itemize}
+\item
+Artin and Mazur \cite{artin-mazur}, 
+\item 
+Arvasi and Odabas \cite{arvasi-odabas}, 
+\item 
+Arvasi and Ulualan \cite{arvasi-ulualan}, 
+\item 
+Brown and Gilbert \cite{brown-gilbert}, 
+\item 
+Brown and Loday \cite{brown-loday}, 
+\item
+Ellis \cite{Ellis}, 
+\item 
+Mac Lane and Whitehead \cite{maclane-whitehead}, 
+\item 
+Mutlu and Porter (TAC) \cite{mutlu-porter-tac}, 
+\item 
+Porter - \emph{The Crossed Menagerie} \cite{porter-notes}, 
+\item 
+Porter (Topology) \cite{porter-topology}. 
+\end{itemize}
+} 
 
 This paper is concerned with the latest contribution to the general programme 
 of "computational higher-dimensional group theory" which forms part of the 
 "higher-dimensional group theory" programme described, for example, 
-by Brown in \cite{brown1}. 
+by Brown in \cite{brown-lms}. 
 
 The $2$-dimensional part of these programmes is concerned with group objects 
 in the categories of groups or groupoids, and these objects may equivalently 
@@ -103,14 +132,14 @@ Section 2 contains a summary of the definitions of these objects,
 with some examples. 
 
 The first computation part of this programme was described in 
-Alp and Wensley \cite{alp2}. 
+Alp and Wensley \cite{alp-wensley-ijac}. 
 The output was the package \XMod\ \cite{xmod} for \GAP\ \cite{gap} which, 
 at the time, contained functions for constructing crossed modules and cat$^1$-groups of groups, and their morphisms, and conversions from one to another. 
 It also contained functions for computing the monoid of derivations of a 
 crossed module, and the equivalend monoid of sections of a cat$^1$-group. 
 The next development of \XMod\ combined with the \GAP\ package \groupoids\ 
 \cite{groupoids} to compute crossed modules of groupoids. 
-Later still, a \GAP package \XModAlg\ \cite{xmodalg} was written to compute 
+Later still, a \GAP\ package \XModAlg\ \cite{xmodalg} was written to compute 
 cat$^1$-algebras and crossed modules of algebras. 
 
 The $3$-dimensional part of the higher-dimensional group theory programme 
@@ -118,7 +147,7 @@ is concerned with objects in the category \catXSq\ of crossed squares
 and the equivalent cat$^2$-groups category \catCatt. 
 The mathematical basis is described in section 3, 
 and some computational details are included in section 4. 
-In section 5 we enumerate the $1,086$ \textcolor{red}{(?)} isomorphism classes 
+In section 5 we enumerate the $1,065$ \textcolor{red}{(?)} isomorphism classes 
 of cat$^2$-group structures on the $92$ groups of order at most $30$. 
 
 The impetus for the study of higher-dimensional groups 
@@ -135,21 +164,20 @@ The interested reader may wish to look at the \GAP\ package
 \section{Crossed Modules and Cat$^{1}$-Groups}
 
 The notion of crossed module, generalizing the notion of a G-module, 
-was introduced by Whitehead \cite{wayted} in the course of his studies on the
-algebraic structure of the second relative homotopy group.
+was introduced by Whitehead \cite{whitehead-II} in the course of his studies 
+on the algebraic structure of the second relative homotopy group.
 
-
-\vspace*{4mm}
-\textcolor{red}
-{[It is confusing having a crossed module $C \to G$ 
-and a cat$^1$-group $G \Rightarrow R$. 
-So changing all the $C \to G$ to $S \to R$, as in XMod. 
-But now $s \in S$ so best not to use $s,t$ as source and target maps 
-in the cat$^1$-group, hence changing to tail and head maps $t,h$. 
-(I've resisted the temptation to change left actions into right actions!) 
-If you are not happy with this, the commit can be ditched.]
-} 
-\vspace*{4mm}
+%\vspace*{4mm}
+%\textcolor{red}
+%{[It is confusing having a crossed module $C \to G$ 
+%and a cat$^1$-group $G \Rightarrow R$. 
+%So changing all the $C \to G$ to $S \to R$, as in XMod. 
+%But now $s \in S$ so best not to use $s,t$ as source and target maps 
+%in the cat$^1$-group, hence changing to tail and head maps $t,h$. 
+%(I've resisted the temptation to change left actions into right actions!) 
+%If you are not happy with this, the commit can be ditched.]
+%} 
+%\vspace*{4mm}
 
 A \emph{crossed module} consists of a group homomorphism 
 $\partial : S \rightarrow R$, endowed with a left action $R$ on $S$ 
@@ -174,15 +202,15 @@ and the second one the \emph{Peiffer identity}.
 We will denote such a crossed module by $\calX = (\partial : S \rightarrow R)$.
 
 A \emph{morphism of crossed modules} 
-$(\alpha ,\beta ) : \calX_{1} \rightarrow \calX_{2}$, 
+$(\sigma ,\rho ) : \calX_{1} \rightarrow \calX_{2}$, 
 where $\calX_{1} = (\partial_{1} : S_{1} \rightarrow R_{1})$ 
 and   $\calX_{2} = (\partial_{2} : S_{2} \rightarrow R_{2})$, 
-consists of two group homomorphisms $\alpha : S_{1} \rightarrow S_{2}$
-and $\beta : R_{1} \rightarrow R_{2}$ such that 
+consists of two group homomorphisms $\sigma : S_{1} \rightarrow S_{2}$
+and $\rho : R_{1} \rightarrow R_{2}$ such that 
 \[ 
-\partial_{2}\circ\alpha ~=~ \beta\circ\partial_{1}, 
+\partial_{2}\circ\sigma ~=~ \rho\circ\partial_{1}, 
 \quad \mbox{and} \quad 
-\alpha(^{r}s) ~=~ ^{(\beta r)}\alpha s 
+\sigma(^{r}s) ~=~ ^{(\rho r)}\sigma s 
 \qquad
 \forall s \in S,~ r \in R.
 \] 
@@ -223,7 +251,10 @@ Recall from \cite{Loday} that a \emph{cat$^{1}$-group} is a triple $(G,t,h)$ con
 the \emph{tail map} $t$ and the \emph{head map} $h$, 
 having a common image $R$ and satisfying the following axioms. 
 \begin{equation} \label{cat1-axioms} 
-t \circ h = h, \quad  h \circ t = t, 
+t \circ t = t, \quad  
+h \circ h = h, \quad  
+t \circ h = h, \quad  
+h \circ t = t, 
 \quad \mbox{and}\quad  [\ker t,\ker h] = 1. 
 \end{equation} 
 A \emph{morphism of cat}$^{1}$\emph{-groups} 
@@ -234,8 +265,8 @@ f \circ t_1 ~=~ t_2 \circ f
 \quad\mbox{and}\quad 
 f \circ h_1 ~=~ h_2 \circ f.
 \] 
-Crossed modules and cat$^{1}$-groups are two-dimensional generalisations 
-of a group. 
+Crossed modules and cat$^{1}$-groups are equivalent two-dimensional 
+generalisations of a group. 
 It was shown in \cite[Lemma 2.2]{Loday} that, 
 setting $S = \ker t,~ R = \im t$ and $\partial = h|_{S}$, 
 then the conjugation action makes $(\partial : S \rightarrow R)$ 
@@ -249,7 +280,7 @@ then $(G,t,h)$ is a cat$^{1}$-group.
 %---------------------------------------------------------------------------% 
 \section{Crossed Squares and Cat$^{2}$-Groups}
 
-The notion of a crossed square is due to Guin-Walery and Loday \cite{walery}. 
+The notion of a crossed square is due to Guin-Walery and Loday \cite{walery-loday}. 
 A \emph{crossed square of groups} $\calS$ is a commutative square of groups 
 \begin{equation} \label{xsq-diag}
 \xymatrix@R=20pt@C=20pt
@@ -361,7 +392,7 @@ there is a universal crossed square defining a tensor product of the crossed mod
 \]
 \end{enumerate}
 
-A crossed square (\ref{xsq-diag}) can be thought of as a horizontal or vertical 
+The crossed square (\ref{xsq-diag}) can be thought of as a horizontal or vertical 
 crossed module of crossed modules:
 \[
 \xymatrix@R=20pt@C=20pt
@@ -381,37 +412,52 @@ crossed module of crossed modules:
 \noindent 
 where $(\kappa,\nu)$ is the boundary of the crossed module with 
 domain $(\lambda : L \rightarrow N)$ and codomain $(\mu : M \rightarrow P)$. 
-(See also \cite{wensley_notes} section 10.2.)
+(See also section 10.2 of \cite{wensley-notes}.)
 
 There is an evident notion of morphism of crossed squares  
 which preserves all the structure, 
 and we obtain a category \textbf{Crs}$^{2}$, the category of crossed squares.
 
-Although when first introduced by Loday and Walery \cite{walery} 
+Although when first introduced by Loday and Walery \cite{walery-loday} 
 the notion of crossed square of groups was not linked to that of cat$^{2}$-groups, 
 it was in this form that Loday gave their generalisation 
 to an $n$-fold structure, cat$^{n}$-groups (see \cite{Loday}). 
 When $n=1$ this is the notion of cat$^1$-group given earlier.
 
 When $n=2$ we obtain a cat$^{2}$-group. 
-Again we have a group $G$, but this time with two independent cat$^{1}$-group 
-structures on it. 
-A \emph{cat$^{2}$-group} is a $5$-tuple, $(G,t_1,h_1,t_2,h_2)$, 
+Again we have a group $G$, but this time with two \emph{independent} 
+cat$^{1}$-group structures on it. 
+So a \emph{cat$^{2}$-group} is a $5$-tuple, $(G,t_1,h_1,t_2,h_2)$, 
 where $(G,t_{i},h_{i}),~ i=1,2$ are cat$^{1}$-groups, and
 \[
-t_{1}t_{2} ~=~ t_{2}t_{1}, \quad 
-h_{1}h_{2} ~=~ h_{2}h_{1}, \quad 
-t_{1}h_{2} ~=~ h_{2}t_{1}, \quad
-t_{2}h_{1} ~=~ h_{1}t_{2}. 
+t_{1} \circ t_{2} ~=~ t_{2} \circ t_{1}, \quad 
+h_{1} \circ h_{2} ~=~ h_{2} \circ h_{1}, \quad 
+t_{1} \circ h_{2} ~=~ h_{2} \circ t_{1}, \quad
+t_{2} \circ h_{1} ~=~ h_{1} \circ t_{2}. 
 \]
-A morphism of cat$^{2}$-groups is a triple $(\alpha ,\beta ,\gamma)$,
-as shown in the diagram diagram
+To emphasise the relationship with crossed squares 
+we may illustrate an \emph{oriented} cat$^2$-group by the diagram 
+\[
+\xymatrix@R=50pt@C=50pt 
+{ G \ar@<+0.4ex>[r]^{t_1,h_1} \ar@<-0.4ex>[r] 
+    \ar@<-0.4ex>[d]_{t_2,h_2} \ar@<+0.4ex>[d] 
+    \ar@<-0.4ex>[rd]^{\ t_1 \circ t_2} \ar@<+0.4ex>[rd]_{h_1 \circ h_2} 
+	& R_1 \ar@<+0.4ex>[d]^{t_2,h_2} \ar@<-0.4ex>[d] \\
+  R_2 \ar@<-0.4ex>[r]_{t_1,h_1} \ar@<+0.4ex>[r] 
+	& R_{12} 
+}
+\]
+where $R_{12}$ is the image of $t_1 \circ t_2 = t_2 \circ t_1$. 
+
+\vspace{3mm}
+A morphism of cat$^{2}$-groups is a triple $(\gamma ,\rho_1 ,\rho_2)$,
+as shown in the diagram 
 \[
 \xymatrix@R=40pt@C=40pt 
-{ R_1 \ar[d]_{\beta} 
-	& G \ar[d]_{\alpha} \ar@<-0.4ex>[l]_{t_1,h_1} \ar@<+0.4ex>[l]  
-	                    \ar@<+0.5ex>[r]^{t_2,h_2} \ar@<-0.4ex>[r] 
-		& R_2 \ar[d]^{\gamma} \\
+{ R_1 \ar[d]_{\rho_1} 
+	& G \ar[d]_{\gamma} \ar@<-0.4ex>[l]_{t_1,h_1} \ar@<+0.4ex>[l]  
+	                    \ar@<+0.4ex>[r]^{t_2,h_2} \ar@<-0.4ex>[r] 
+		& R_2 \ar[d]^{\rho_2} \\
   R'_1 
 	& G' \ar@<+0.4ex>[l]^{t'_1,h'_1} \ar@<-0.4ex>[l] 
 	     \ar@<-0.4ex>[r]_{t'_2,h'_2} \ar@<+0.4ex>[r] 
@@ -419,19 +465,19 @@ as shown in the diagram diagram
 }
 \]
 \noindent where 
-$\alpha : G \to G^{\prime},~ \beta = \alpha|_{R_1}$ 
-and $\gamma = \alpha|_{R_2}$ are homomorphisms satisfying: 
+$\gamma : G \to G^{\prime},~ \rho_1 = \gamma|_{R_1}$ 
+and $\rho_2 = \gamma|_{R_2}$ are homomorphisms satisfying: 
 \[ 
-\beta \circ t_1 = t_1^{\prime} \circ \alpha, \qquad 
-\beta \circ h_1 = h_1^{\prime} \circ \alpha, \qquad 
-\gamma \circ t_2 = s_2^{\prime} \circ \alpha, \qquad 
-\gamma \circ h_2 = h_2^{\prime} \circ \alpha. 
+\rho_1 \circ t_1 = t_1^{\prime} \circ \gamma, \qquad 
+\rho_1 \circ h_1 = h_1^{\prime} \circ \gamma, \qquad 
+\rho_2 \circ t_2 = t_2^{\prime} \circ \gamma, \qquad 
+\rho_2 \circ h_2 = h_2^{\prime} \circ \gamma. 
 \] 
 We thus obtain a category \textbf{Cat}$^{2}$\textbf{-Grp}, 
 the category of cat$^{2}$-groups. 
 The following proposition was given by Loday \cite{Loday}. 
-We only present the sketch proof (see also \cite{mutpor}) of this result 
-as we need some indication of proofs for later use.
+We only present the sketch proof (see also \cite{mutlu-porter-2003}) 
+of this result as we need some indication of proofs for later use.
 
 \begin{proposition}
 \label{loday} \emph{(\cite{Loday})} 
@@ -492,7 +538,7 @@ t_{i}h_{j} = h_{j}t_{i}.
 \end{definition}
 
 A generalisation of crossed square to higher dimensions was given by Ellis
-and Stenier (cf. \cite{Sten}). 
+and Stenier (cf. \cite{ellis-stenier}). 
 It is called a \textquotedblleft crossed $n$-cube \textquotedblright. 
 We only use this construction for $n=2$.
 
@@ -510,7 +556,7 @@ These contributions are organized in a form of \GAP\ packages
 and are distributed together with the system.  Contributors can
 submit additional packages for inclusion after a reviewing process.
 
-The Small Groups library by Besche, Eick and O'Brien in \cite{bettina} 
+The Small Groups library by Besche, Eick and O'Brien in \cite{besche-eick-obrien} 
 provides access to descriptions of the groups of small order. 
 The groups are listed up to isomorphism. 
 The library contains all groups of order at most 2000 except 1024.
@@ -552,13 +598,16 @@ Using small generating set [ f1, f2 ] for source of homs.
 [triv->A4]
 \end{Verbatim}
 
-A more general notion of cat$^1$-group is implemented in \XMod\, 
+A more general notion of cat$^1$-group is implemented in \XMod, 
 where the tail and head maps are no longer required to be endomorphisms on $G$. 
 Instead it is required that $tG=hG=R$, and an \emph{embedding} $e : R \to G$ 
 is added.  
 The axioms in (\ref{cat1-axioms}) then become:  
 \[ 
-t \circ e \circ h = h, \quad  h \circ e \circ t = t, 
+t \circ e \circ t = t, \quad  
+h \circ e \circ h = h, \quad  
+t \circ e \circ h = h, \quad  
+h \circ e \circ t = t, 
 \quad \mbox{and}\quad  [\ker t,\ker h] = 1. 
 \] 
 We denote such a cat$^1$-group by $(e;t,h : G \to R)$. 
@@ -577,18 +626,24 @@ Attributes of a (pre)cat$^{2}$-group constructed in this way include
 
 As with cat$^1$-groups, we use a more general notion for cat$^2$-groups. 
 An \emph{oriented cat$^2$-group} has the form 
+\textcolor{red}
+{(labels on the diagonal arrows need correcting)} 
 \[
-\xymatrix@R=40pt@C=60pt
-{ G \ar[d]_{t_2,h_2} \ar[r]^{t_1,h_1}  
-	  & R_1 \ar[d]^{t_2*e_2*t_1*e_1} \\ 
-  R_2 \ar[r]_{t_1*e_1*t_2*e_2} 
-	  & R_{12} }  
+\xymatrix@R=60pt@C=60pt 
+{ G \ar@<+0.5ex>[r]^{t_1,h_1} \ar@<+0.1ex>[r] 
+    \ar@<-0.5ex>[d]_{t_2,h_2} \ar@<-0.1ex>[d] 
+    \ar@<+0.5ex>[rd]^{t_1t_2} \ar@<+0.1ex>[rd]_{h_1h_2} 
+	& R_1 \ar@<+0.5ex>[d]^{t_2,h_2} \ar@<+0.1ex>[d] 
+	      \ar@<+0.4ex>[l]^{e_1} \\
+  R_2 \ar@<+0.5ex>[r]^{t_1,h_1} \ar@<+0.1ex>[r] 
+      \ar@<-0.4ex>[u]_{e_2} 
+	& R_{12} \ar@<+0.4ex>[l]^{e_1} \ar@<+0.4ex>[u]^{e_2} 
+	         \ar@<+0.4ex>[ul]^{e_2} 
+}
 \]
 where $R_1, R_2$ need not be subgroups of $G$, 
 but $R_{12}$ is taken to be the common image of 
 $t_1*e_1*t_2*h_2$ and $t_2*e_2*t_1*e_1$, a subgroup of $G$. 
-\textcolor{red}
-{[need to add $e_1,e_2$ to the diagram]} 
 
 
 Generalizing these functions, we have introduced \textbf{Cat3Group} and \textbf{HigherDimension} which construct cat$^{3}$-groups. 
@@ -633,6 +688,7 @@ cat2-group with generating (pre-)cat1-groups:
 1 : [c4c2:c2 => Group( [ (), (), (2,6)(4,8) ] )]
 2 : [c4c2:c2 => Group( [ (1,2,3,4)(5,6,7,8), (), () ] )]
 \end{Verbatim}
+
 
 %............................................%
 \subsection{Morphisms of 3-Dimensional Groups}
@@ -690,6 +746,7 @@ true
 
 %\textcolor{red}{Do we omit this, correct it, or find a better example?} 
 
+
 %..............................%
 \subsection{Natural Equivalence}
 
@@ -745,12 +802,13 @@ true
 %---------------------------------------------------------------------------% 
 \section{Table of cat$^{2}$-groups}
 
-The new the function \textbf{AllCat2Groups(G)} which constructs all cat$^{2}$%
--groups $(G,s_1,t_1,s_2,t_2)$ over $G$. The function \textbf{%
-	AreIsomorphicCat2Groups} is used for checking isomorphism among cat$^{2}$%
--groups. The functions \textbf{IsomorphicCat2GroupFamily} and \textbf{%
-	AllCat2GroupsUpToIsomorphism} are used to used to classify given cat$^{2}$%
--groups.
+The function \textbf{AllCat2Groups(G)} constructs all cat$^{2}$-groups 
+$(G,t_1,h_1,t_2,h_2)$ over $G$. 
+The function \textbf{AreIsomorphicCat2Groups} is used for checking whether 
+or not two cat$^{2}$-groups are isomorphic. 
+The functions \textbf{IsomorphicCat2GroupFamily} 
+and \textbf{AllCat2GroupsUpToIsomorphism} 
+are used to used to classify given cat$^{2}$-groups.
 
 In the following \GAP\ session, we compute all cat$^{2}$-groups on $C_{4}
 \times C_{2}$ and their isomorphism families. 
@@ -778,7 +836,7 @@ cat2-group with generating (pre-)cat1-groups:
 false
 \end{Verbatim}
 
-In the following table the groups of size at most $30$ are ordered by their
+In the following tables the groups of size at most $30$ are ordered by their
 \GAP\ number. 
 For each group $G$ we list the number $|IE(G)|$ of idempotent endomorphisms; 
 the number $|\calC^1(G)|$ of cat$^1$-groups on $G$, 
@@ -786,19 +844,23 @@ followed by the number of isomorphism classes of these;
 and then the number $|\calC^2(G)|$ of cat$^2$-groups on $G$, 
 and the number of these isomorphism classes. 
 The number of isomorphism classes $\calC^1(G)$ of cat$^{1}$-groups 
-is given in \cite{alp2}. 
+is given in \cite{alp-wensley-ijac}. 
 The size of the set of all cat$^{2}$-groups and the number of isomorphism classes 
 of cat$^{2}$-groups on $G$ are computed by given the functions in the manuscript.
 
-We may reduce the size of the table by noting the results for certain simple families. 
+We may reduce the size of the table by noting the results for cyclic groups. 
 When $G=C_{p^{k}}$ is cyclic, with $p$ prime, 
 the only idempotent endomorphisms are the identity and zero maps. 
-
-All the cat$^1$-groups have equal tail and head maps, 
+In this case all the cat$^1$-groups have equal tail and head maps, 
 and all isomorphism classes are singletons. 
-The groups row in the table below lists, for each cat$^2$-group, its four groups. 
-
-%\textcolor{red}{(Check this!)} 
+Similarly, when $G = C_{p_1^{k_1}p_2^{k_2} \ldots p_m^{k_m}}$ is cyclic, 
+and its order is the product of $m$ distinct primes $p_i$ 
+having multiplicities $k_i$, 
+there are $2^m$ idempotent endomorphisms and cat$^1$-groups.  
+We thus obtain the following results up to $m=4$. 
+The rows headed 'groups' list, for each cat$^2$-group, its four groups 
+$[G,R_1,R_2,R_{12}]$ where, for example, $2 \times [G,I,C_x,I]$ 
+denotes $\{[G,I,C_{p_1},I],[G,I,C_{p_2},I]\}$. 
 
 \bigskip
 \begin{longtable}{ccccccc}
@@ -809,8 +871,8 @@ The groups row in the table below lists, for each cat$^2$-group, its four groups
 	            & $|\calC^1(G)/\cong |$ 
 	                & $|\calC^{2}(G)|$ 
 	                    & $|\calC^{2}(G)/\cong |$ \\ 
-    \hline
-	& $C_{p^{k}}$ 
+    \hline\hline 
+	& $C_{p_1^{k_1}}$ 
 	    & 2 
 	        & 2 
 	            & 2 
@@ -822,26 +884,8 @@ The groups row in the table below lists, for each cat$^2$-group, its four groups
 			groups  & $[G,I,I,I],~ [G,I,G,I],~ [G,G,G,G]$  
 		\end{tabular}%
 	} \\ 
-	\hline
-\end{longtable}
-
-\bigskip
-
-When $G$ is cyclic and its order is the product of at most four distinct primes,
-we obtain the following, 
-where $2 \times [G,I,C_x,I]$ denotes $\{[G,I,C_p,I],[G,I,C_q,I]\}$. 
-
-\bigskip
-\begin{longtable}{ccccccc}
-	\hline\hline
-	& $G$ 
-	    & $|\mathrm{IE}(G)|$ 
-	        & $|\calC^1(G)|$ 
-	            & $|\calC^1(G)/\cong |$ 
-	                & $|\calC^{2}(G)|$ 
-	                    & $|\calC^{2}(G)/\cong |$ \\ 
-	\hline
-	& $C_{p^{k}q^{j}}$ 
+	\hline\hline 
+	& $C_{p_1^{k_1}p_2^{k_2}}$ 
 	    & 4 
 	        & 4 
 	            & 4 
@@ -852,11 +896,11 @@ where $2 \times [G,I,C_x,I]$ denotes $\{[G,I,C_p,I],[G,I,C_q,I]\}$.
 		\begin{tabular}{ll}
 			groups & $[G,I,I,I],~ [G,I,G,I],~ [G,G,G,G],~ 2 \times [G,I,C_x,I],$ \\
 				   & $2 \times [G,C_x,G,C_x],~ 2 \times [G,C_x,C_x,C_x],~ 
-				     [G,C_p,C_q,I]$%
+				     [G,C_{p_1},C_{p_2},I]$%
 		\end{tabular}%
 	} \\ 
-	\hline
-	& $C_{p^{k}q^{j}r^{i}}$ 
+	\hline\hline 
+	& $C_{p_1^{k_1}p_2^{k_2}p_3^{k_3}}$ 
 	    & 8 
 	        & 8 
 	            & 8 
@@ -874,79 +918,82 @@ where $2 \times [G,I,C_x,I]$ denotes $\{[G,I,C_p,I],[G,I,C_q,I]\}$.
 				     3 \times [G,C_{xz},C_{yz},C_z]$%
 		\end{tabular}%
 	} \\ 
-	\hline
-	& $C_{p^{k}q^{j}r^{i}s^{h}}$ 
+	\hline\hline 
+	& $C_{p_1^{k_1}p_2^{k_2}p_3^{k_3}p_4^{k_4}}$ 
 	    & 16 
 	        & 16 
 	            & 16 
 	                & 136 
 	                    & 136 \\ 
-	\hline
-\end{longtable}
-
-\bigskip
-
-When $G=C_{2p}\times C_{2}$ with $p>2$ and $p$ prime 
-(e.g. $C_{6} \times C_{2}, C_{10} \times C_{2}, C_{14} \times C_{2}, \ldots$). 
-
-\vspace*{10mm}
-\textcolor{red}
-{[We should probably not include the lengthy groups list for this case, 
-because, for example, there is more than one idempotent endomorphism 
-with image $C_2$, so it is not clear what $[G,I,C_2,I],[G,I,C_2,I]$ means. 
-But, for now, just add the missing 32nd entry \texttt{[G,I,G,I]}.]}
-
-\textcolor{blue}
-{[OK, You are right]}  
-
-\bigskip
-\begin{longtable}{ccccccc}
 	\hline\hline
-	& $G$ 
-	    & $|\mathrm{IE}(G)|$ 
-	        & $|\calC^1(G)|$ 
-	            & $|\calC^1(G)/\cong |$ 
-	                & $|\calC^{2}(G)|$ 
-	                    & $|\calC^{2}(G)/\cong |$ \\ 
-	\hline
-	& $C_{2p}\times C_{2}$ 
-	    & 16 
-	        & 28 
-	            & 8 
-	                & 136 
-	                    & 32 \\ 
-	\hline
-	\multicolumn{7}{l}{%
-		\begin{tabular}{ll}
-			groups & $[G,I,I,I],~ [G,I,C_2,I],~ [G,I,C_2,I],~ [G,C_2,C_2,C_2],~ 
-			          [G,C_2,C_2,I],$ \\ 
-                   & $[G,I,C_2 \times C_2,I],~ [G,C_2,C_2 \times C_2,C_2],~ 
-                      [G,C_2,C_2 \times C_2,C_2],$ \\ 
-                   & $[G,C_2 \times C_2,C_2 \times C_2,C_2 \times C_2],~ 
-                      [G,I,C_p,I],~ [G,C_2,C_p,I],$ \\ 
-                   & $[G,C_2,C_p,I],~ [G,C_2 \times C_2,C_p,I],~ [G,C_p,C_p,C_p],~ 
-                      [G,I,C_{2p},I],$ \\ 
-                   & $[G,I,C_{2p},I],~ [G,C_2,C_{2p},C_2],~ [G,C_2,C_{2p},I],~ 
-                      [G,C_2 \times C_2,C_{2p},C_2],$ \\ 
-                   & $[G,C_2 \times C_2,C_{2p},C_2],~ [G,C_p,C_{2p},C_p],~ 
-                      [G,C_p,C_{2p},C_p],$ \\ 
-                   & $[G,C_{2p},C_{2p},C_{2p}],~ [G,C_{2p},C_{2p},C_p],~ 
-                      [G,C_2 \times C_2,C_{2p} \times C_2,C_2 \times C_2],$ \\ 
-                   & $[G,C_2,C_{2p} \times C_2,C_2],~ 
-                      [G,C_2,C_{2p} \times C_2,C_2],~ 
-                      [G,C_p,C_{2p} \times C_2,C_p],$ \\ 
-                   & $[G,C_{2p},C_{2p} \times C_2,C_{2p}],~ 
-                      [G,C_{2p},C_{2p} \times C_2,C_{2p}],~ [G,I,G,I],~ [G,G,G,G]$ 
-		\end{tabular}%
-	} \\ 
-	\hline
 \end{longtable}
 
-The following table contains results for those $G$ which do not belong 
-to one of these families. 
+\noindent 
+When $m=1$ there are $16$ groups of order at most $30$; 
+when $m=2$ there are $12$ such groups; 
+and when $m=3$ there is just the small group $30/4 = C_{30}$. 
+
+%\bigskip
+%When $G=C_{2p}\times C_{2}$ with $p>2$ and $p$ prime 
+%(e.g. $C_{6} \times C_{2}, C_{10} \times C_{2}, C_{14} \times C_{2}, \ldots$). 
+%
+%\vspace*{10mm}
+%\textcolor{red}
+%{[We should probably not include the lengthy groups list for this case, 
+%because, for example, there is more than one idempotent endomorphism 
+%with image $C_2$, so it is not clear what $[G,I,C_2,I],[G,I,C_2,I]$ means. 
+%But, for now, just add the missing 32nd entry \texttt{[G,I,G,I]}.]}
+%
+%\textcolor{blue}
+%{[OK, You are right]}  
+
+%\bigskip
+%\begin{longtable}{ccccccc}
+%	\hline\hline
+%	& $G$ 
+%	    & $|\mathrm{IE}(G)|$ 
+%	        & $|\calC^1(G)|$ 
+%	            & $|\calC^1(G)/\cong |$ 
+%	                & $|\calC^{2}(G)|$ 
+%	                    & $|\calC^{2}(G)/\cong |$ \\ 
+%	\hline
+%	& $C_{2p}\times C_{2}$ 
+%	    & 16 
+%	        & 28 
+%	            & 8 
+%	                & 136 
+%	                    & 32 \\ 
+%	\hline
+%	\multicolumn{7}{l}{%
+%		\begin{tabular}{ll}
+%			groups & $[G,I,I,I],~ [G,I,C_2,I],~ [G,I,C_2,I],~ [G,C_2,C_2,C_2],~ 
+%			          [G,C_2,C_2,I],$ \\ 
+%                   & $[G,I,C_2 \times C_2,I],~ [G,C_2,C_2 \times C_2,C_2],~ 
+%                      [G,C_2,C_2 \times C_2,C_2],$ \\ 
+%                   & $[G,C_2 \times C_2,C_2 \times C_2,C_2 \times C_2],~ 
+%                      [G,I,C_p,I],~ [G,C_2,C_p,I],$ \\ 
+%                   & $[G,C_2,C_p,I],~ [G,C_2 \times C_2,C_p,I],~ [G,C_p,C_p,C_p],~ 
+%                      [G,I,C_{2p},I],$ \\ 
+%                   & $[G,I,C_{2p},I],~ [G,C_2,C_{2p},C_2],~ [G,C_2,C_{2p},I],~ 
+%                      [G,C_2 \times C_2,C_{2p},C_2],$ \\ 
+%                   & $[G,C_2 \times C_2,C_{2p},C_2],~ [G,C_p,C_{2p},C_p],~ 
+%                      [G,C_p,C_{2p},C_p],$ \\ 
+%                   & $[G,C_{2p},C_{2p},C_{2p}],~ [G,C_{2p},C_{2p},C_p],~ 
+%                      [G,C_2 \times C_2,C_{2p} \times C_2,C_2 \times C_2],$ \\ 
+%                   & $[G,C_2,C_{2p} \times C_2,C_2],~ 
+%                      [G,C_2,C_{2p} \times C_2,C_2],~ 
+%                      [G,C_p,C_{2p} \times C_2,C_p],$ \\ 
+%                   & $[G,C_{2p},C_{2p} \times C_2,C_{2p}],~ 
+%                      [G,C_{2p},C_{2p} \times C_2,C_{2p}],~ [G,I,G,I],~ [G,G,G,G]$ 
+%		\end{tabular}%
+%	} \\ 
+%	\hline\hline 
+%\end{longtable}
+
+The following table contains results for those $G$ are not cyclic. 
 %{\small \
 \begin{longtable}{ccrrrrr}
-	\hline\hline
+	\hline 
 	{\GAP\ }\# 
 	    & $G$ 
 	        & $|\mathrm{IE}(G)|$ 
@@ -955,67 +1002,70 @@ to one of these families.
 	                    & $|\calC^{2}(G)|$ 
 	                        & $|\calC^{2}(G)/\cong |$  \\ 
 	\hline
-	1/1 & I & 1 & 1 & 1 & 1 & 1 \\ 
-	4/2 & K4 & 8 & 14 & 4 & 36 & 9 \\ 
-	6/1 & S3 & 5 & 4 & 2 & 7 & 3 \\ 
-	8/2 & C4 $\times$ C2 & 10 & 18 & 6 & 47 & 14 \\ 
-	8/3 & D8 & 10 & 9 & 3 & 17 & 5 \\ 
-	8/4 & Q8 & 2 & 1 & 1 & 1 & 1 \\ 
-	8/5 & C2 $\times$ C2 $\times$ C2 & 58 & 226 & 6 & 1,711 & 23 \\ 
-	9/2 & C3 $\times$ C3 & 14 & 38 & 4 & 93 & 9 \\ 
-	10/1 & D10 & 7 & 6 & 2 & 11 & 3 \\ 
-	12/1 & C3 $\ltimes$ C4 & 5 & 4 & 2 & 7 & 3 \\ 
-	12/3 & A4 & 6 & 5 & 2 & 9 & 3 \\ 
-	12/4 & D12 & 21 & 12 & 4 & 41 & 10 \\ 
-	14/1 & D14 & 9 & 8 & 2 & 15 & 3 \\ 
-	16/2 & C4 $\times$ C4 & 26 & 98 & 5 & 231 & 11 \\ 
-	16/3 & (C4 $\times$ C2) $\ltimes$ C2 & 18 & 25 & 4 & 41 & 6 \\ 
-	16/4 & C4 $\ltimes$ C4 & 10 & 17 & 3 & 25 & 4 \\ 
-	16/5 & C8 $\times$ C2 & 10 & 18 & 6 & 47 & 14 \\ 
-	16/6 & C8 $\ltimes$ C2 & 6 & 5 & 2 & 9 & 3 \\ 
-	16/7 & D16 & 18 & 9 & 2 & 17 & 3 \\ 
-	16/8 & QD16 & 10 & 5 & 2 & 9 & 3 \\ 
-	16/9 & Q16 & 2 & 1 & 1 & 1 & 1 \\ 
-	16/10 & C4 $\times$ C2 $\times$ C2 & 82 & 322 & 12 & 2,875 & 53 \\ 
-	16/11 & C2 $\times$ D8 & 82 & 97 & 9 & 473 & 24 \\ 
-	16/12 & C2 $\times$ Q8 & 18 & 17 & 3 & 25 & 4 \\ 
-	16/13 & (C4 $\times$ C2) $\ltimes$ C2 & 26 & 13 & 2 & 25 & 3 \\ 
-	16/14 & C2 $\times$ C2 $\times$ C2 $\times$ C2 
-	          & 382 & 4,162 & 9 & 298,483 & 53  \\ 
-	18/1 & D18 & 11 & 10 & 2 & 19 & 4 \\ 
-	18/3 & C3 $\times$ S3 & 12 & 8 & 4 & 24 & 10 \\ 
-	18/4 & (C3 $\times$ C3) $\ltimes$ C2 & 47 & 118 & 4 & 541 & 9 \\ 
-	18/5 & C6 $\times$ C3 & 28 & 76 & 8 & 358 & 32 \\ 
-	20/1 & Q20 & 7 & 6 & 2 & 11 & 3 \\ 
-	20/3 & C4 $\ltimes$ C5 & 7 & 6 & 2 & 11 & 3 \\ 
-	20/4 & D20 & 31 & 18 & 4 & 65 & 10 \\ 
-	21/1 & C3 $\ltimes$ C7 & 9 & 8 & 2 & 15 & 3 \\ 
-	22/1 & D22 & 13 & 12 & 2 & 23 & 3 \\ 
-	24/1 & C3$\ltimes$C8 & 5 & 4 & 2 & 7 & 3 \\ 
-	24/3 & SL(2,3) & 6 & 1 & 1 & 1 & 1 \\ 
-	24/4 & Q24 & 5 & 4 & 2 & 7 & 3 \\ 
-	24/5 & S3 $\times$ C4 & 27 & 12 & 4 & 41 & 10 \\ 
-	24/6 & D24 & 33 & 20 & 4 & 75 & 10 \\ 
-	24/7 & Q12 $\times$ C2 & 25 & 36 & 6 & 115 & 14 \\ 
-	24/8 & D8 $\ltimes$ C3 & 23 & 12 & 4 & 41 & 10 \\ 
-	24/9 & C12 $\times$ C2 & 20 & 36 & 12 & 178 & 52 \\ 
-	24/10 & D8 $\times$ C3 & 20 & 18 & 6 & 59 & 17 \\ 
-	24/11 & Q8 $\times$ C3 & 4 & 2 & 2 & 3 & 3 \\ 
-	24/12 & S4 & 12 & 5 & 2 & 9 & 3 \\ 
-	24/13 & A4 $\times$ C2 & 15 & 10 & 4 & 31 & 10 \\ 
-	24/14 & S3 $\times$ K4 & 157 & 116 & 8 & 999 & 32 \\ 
-	24/15 & C6 $\ltimes$ K4 & 116 & 452 & 12 & 6,786 & 88 \\ 
-	25/2 & C5 $\times$ C5 & 32 & 152 & 4 & 348 & 9 \\ 
-	26/1 & D26 & 15 & 14 & 2 & 27 & 3 \\ 
-	27/2 & C9 $\times$ C3 & 20 & 56 & 6 & 138 & 14 \\ 
-	27/3 & (C3 $\times$ C3) $\ltimes$ C3 & 38 & 37 & 2 & 73 & 3 \\ 
-	27/4 & C9 $\ltimes$C3 & 11 & 10 & 2 & 19 & 3 \\ 
-	27/5 & C3 $\times$ C3 $\times$ C3 & 236 & 2,108 & 6 & 24,222  & 16 \\ 
-	28/1 & Q28 & 9 & 8 & 2 & 15 & 3 \\ 
-	28/3 & D28 & 41 & 24 & 4 & 89 & 10 \\ 
-	30/1 & D6 $\times$ C5 & 10 & 8 & 4 & 24 & 10 \\ 
-	30/2 & D10 $\times$ C3 & 14 & 12 & 4 & 38 & 10 \\ 
-	30/3 & D30 & 25 & 24 & 4 & 92 & 10 \\ \hline
+	1/1 & $I$ & 1 & 1 & 1 & 1 & 1 \\ 
+	4/2 & $K_4 = C_2 \times C_2$ & 8 & 14 & 4 & 36 & 9 \\ 
+	6/1 & $S_3$ & 5 & 4 & 2 & 7 & 3 \\ 
+	8/2 & $C_4 \times C_2$ & 10 & 18 & 6 & 47 & 14 \\ 
+	8/3 & $D_8$ & 10 & 9 & 3 & 17 & 5 \\ 
+	8/4 & $Q_8$ & 2 & 1 & 1 & 1 & 1 \\ 
+	8/5 & $C_2 \times C_2 \times C_2$ & 58 & 226 & 6 & 1,711 & 23 \\ 
+	9/2 & $C_3 \times C_3$ & 14 & 38 & 4 & 93 & 9 \\ 
+	10/1 & $D_{10}$ & 7 & 6 & 2 & 11 & 3 \\ 
+	12/1 & $C_3 \ltimes C_4$ & 5 & 4 & 2 & 7 & 3 \\ 
+	12/3 & $A_4$ & 6 & 5 & 2 & 9 & 3 \\ 
+	12/4 & $D_{12}$ & 21 & 12 & 4 & 41 & 10 \\ 
+	12/5 & $C_3 \times K_4$ & 16 & 28 & 8 & 136 & 32 \\ 
+	14/1 & $D_{14}$ & 9 & 8 & 2 & 15 & 3 \\ 
+	16/2 & $C_4 \times C_4$ & 26 & 98 & 5 & 231 & 11 \\ 
+	16/3 & $(C_4 \times C_2) \ltimes C_2$ & 18 & 25 & 4 & 41 & 6 \\ 
+	16/4 & $C_4 \ltimes C_4$ & 10 & 17 & 3 & 25 & 4 \\ 
+	16/5 & $C_8 \times C_2$ & 10 & 18 & 6 & 47 & 14 \\ 
+	16/6 & $C_8 \ltimes C_2$ & 6 & 5 & 2 & 9 & 3 \\ 
+	16/7 & $D_{16}$ & 18 & 9 & 2 & 17 & 3 \\ 
+	16/8 & $QD_{16}$ & 10 & 5 & 2 & 9 & 3 \\ 
+	16/9 & $Q_{16}$ & 2 & 1 & 1 & 1 & 1 \\ 
+	16/10 & $C_4 \times K_4$ & 82 & 322 & 12 & 2,875 & 53 \\ 
+	16/11 & $C_2 \times D_8$ & 82 & 97 & 9 & 473 & 24 \\ 
+	16/12 & $C_2 \times Q_8$ & 18 & 17 & 3 & 25 & 4 \\ 
+	16/13 & $(C4 \times C2) \ltimes C_2$ & 26 & 13 & 2 & 25 & 3 \\ 
+	16/14 & $K_4 \times K_4$ & 382 & 4,162 & 9 & 298,483 & 53  \\ 
+	18/1 & $D_{18}$ & 11 & 10 & 2 & 19 & 4 \\ 
+	18/3 & $C_3 \times S_3$ & 12 & 8 & 4 & 24 & 10 \\ 
+	18/4 & $(C_3 \times C_3) \ltimes C_2$ & 47 & 118 & 4 & 541 & 9 \\ 
+	18/5 & $C_6 \times C_3$ & 28 & 76 & 8 & 358 & 32 \\ 
+	20/1 & $Q_{20}$ & 7 & 6 & 2 & 11 & 3 \\ 
+	20/3 & $C_4 \ltimes C_5$ & 7 & 6 & 2 & 11 & 3 \\ 
+	20/4 & $D_{20}$ & 31 & 18 & 4 & 65 & 10 \\ 
+	20/5 & $C_5 \times K_4$ & 16 & 28 & 8 & 136 & 32 \\ 
+	21/1 & $C_3 \ltimes C_7$ & 9 & 8 & 2 & 15 & 3 \\ 
+	22/1 & $D_{22}$ & 13 & 12 & 2 & 23 & 3 \\ 
+	24/1 & $C_3 \ltimes C_8$ & 5 & 4 & 2 & 7 & 3 \\ 
+	24/3 & $SL(2,3)$ & 6 & 1 & 1 & 1 & 1 \\ 
+	24/4 & $Q_{24}$ & 5 & 4 & 2 & 7 & 3 \\ 
+	24/5 & $S_3 \times C_4$ & 27 & 12 & 4 & 41 & 10 \\ 
+	24/6 & $D_{24}$ & 33 & 20 & 4 & 75 & 10 \\ 
+	24/7 & $Q_{12} \times C_2$ & 25 & 36 & 6 & 115 & 14 \\ 
+	24/8 & $D_8 \ltimes C_3$ & 23 & 12 & 4 & 41 & 10 \\ 
+	24/9 & $C_{12} \times C_2$ & 20 & 36 & 12 & 178 & 52 \\ 
+	24/10 & $D_8 \times C_3$ & 20 & 18 & 6 & 59 & 17 \\ 
+	24/11 & $Q_8 \times C_3$ & 4 & 2 & 2 & 3 & 3 \\ 
+	24/12 & $S_4$ & 12 & 5 & 2 & 9 & 3 \\ 
+	24/13 & $A_4 \times C_2$ & 15 & 10 & 4 & 31 & 10 \\ 
+	24/14 & $S_3 \times K_4$ & 157 & 116 & 8 & 999 & 32 \\ 
+	24/15 & $C_6 \ltimes K_4$ & 116 & 452 & 12 & 6,786 & 88 \\ 
+	25/2 & $C_5 \times C_5$ & 32 & 152 & 4 & 348 & 9 \\ 
+	26/1 & $D_{26}$ & 15 & 14 & 2 & 27 & 3 \\ 
+	27/2 & $C_9 \times C_3$ & 20 & 56 & 6 & 138 & 14 \\ 
+	27/3 & $(C_3 \times C_3) \ltimes C_3$ & 38 & 37 & 2 & 73 & 3 \\ 
+	27/4 & $C_9 \ltimes C_3$ & 11 & 10 & 2 & 19 & 3 \\ 
+	27/5 & $C_3 \times C_3 \times C_3$ & 236 & 2,108 & 6 & 24,222  & 16 \\ 
+	28/1 & $Q_{28}$ & 9 & 8 & 2 & 15 & 3 \\ 
+	28/3 & $D_{28}$ & 41 & 24 & 4 & 89 & 10 \\ 
+	28/4 & $C_7 \times K_4$ & 16 & 28 & 8 & 136 & 32 \\ 
+	30/1 & $S_3 \times C_5$ & 10 & 8 & 4 & 24 & 10 \\ 
+	30/2 & $D_{10} \times C_3$ & 14 & 12 & 4 & 38 & 10 \\ 
+	30/3 & $D_{30}$ & 25 & 24 & 4 & 92 & 10 \\ 
+	\hline
 \end{longtable}
 %}
 
@@ -1027,39 +1077,28 @@ The first and second authors were supported by Eskisehir Osmangazi
 University Scientific Research Projects (Grant No: 2017/19033).
 
 
-\vspace*{10mm}
-\noindent
-\textcolor{red}
-{[What is the correct bibliography convention? 
-  Are not the \emph{titles} emphasised, and not the Journal name?]} 
-
 \begin{thebibliography}{99}
-	\bibitem{alp2} \textsc{Alp M. and Wensley C.D.}, 
-	Enumeration of cat$^{1}$-groups of low order, 
-	\emph{Int. J. Algebra Comput.}, 10, 407-424, (2000).
+	\bibitem{alp-wensley-ijac} \textsc{Alp, M.} and \textsc{Wensley, C.D.}, 
+	\emph{Enumeration of cat$^{1}$-groups of low order}, 
+	Int. J. Algebra Comput., 10, 407-424 (2000).
 	
-	\bibitem{Artin} \textsc{M. Artin} and \textsc{B. Mazur}, 
-	\textrm{On the Van Kampen theorem, } 
-	\emph{Topology,} \textbf{5}, 179-189, (1966).
+	\bibitem{artin-mazur} \textsc{Artin, M.} and \textsc{Mazur, B.}, 
+	\emph{On the Van Kampen theorem},  
+	Topology, \textbf{5}, 179-189 (1966).
 	
-	\bibitem{arvasi2} \textsc{Arvasi Z. and Ulualan E.}, 
-	On Algebraic Models for Homotopy 3-types, 
-	\emph{Journal of Homotopy and Related Structures}, 1, 1-27, (2006).
+	\bibitem{xmodalg} \textsc{Arvasi, Z.} and \textsc{Odabas, A.},  
+	\emph{Crossed Modules and cat$^1$-algebras}, 
+	{(manual for the \textsf{XModAlg} share package for \GAP, version 1.12  
+	(2015)).} 
 	
-	\bibitem{xmodalg} \textsc{Arvasi Z. and Odabas A.},  
-	Crossed Modules and Cat$^1$-algebras, 
-	{(manual for the \textsf{XModAlg} share package for \GAP, version 1.12, 
-	(2015).)} 
+	\bibitem{arvasi-odabas} \textsc{Arvasi, Z.} and \textsc{Odabas, A.}, 
+	\emph{Computing 2-dimensional algebras: Crossed modules and Cat$^1$-algebras}, 
+	J. Algebra Appl., 15, 165-185 (2016).
 	
-	\bibitem{odabas} \textsc{Arvasi Z. and Odabas A.}, 
-	Computing 2-dimensional algebras: Crossed modules and Cat1-algebras, 
-	\emph{J. Algebra Appl.}, 15, 1650185 (2016).
-	
-	\bibitem{gap} \textsc{The GAP Group},
-	GAP -- Groups, Algorithms, and Programming, Version 4.10.2; (2019). 
-	(https://www.gap-system.org).
-	
-	
+	\bibitem{arvasi-ulualan} \textsc{Arvasi, Z.} and \textsc{Ulualan, E.}, 
+	\emph{On Algebraic Models for Homotopy $3$-types}, 
+	J. Homotopy and Related Structures, 1, 1-27, (2006).
+		
 	%\bibitem{baus1} \textsc{H.J. Baues}, 
 	%\textrm{Algebraic homotopy, } 
 	%\emph{Cambridge Studies in Advanced Mathematics, } 
@@ -1074,27 +1113,29 @@ University Scientific Research Projects (Grant No: 2017/19033).
 	%and algebraic 3-types of spaces, } 
 	%\emph{Contemporary Mathematics,} \textbf{227}, 46-66, (1999).
 	
-	\bibitem{Brown} \textsc{R. Brown} and \textsc{J.-L. Loday}, 
-	\textrm{Van Kampen theorems for diagram of spaces,} 
-	\emph{Topology,} \textbf{26}, 311-335, (1987).
+	\bibitem{besche-eick-obrien} 
+	\textsc{Besche, H.U.}, \textsc{Eick, B.} and \textsc{O'Brien, E.A.}, 
+	\emph{A millennium project: constructing Small Groups}, 
+	Internat. J. Algebra Comput., 12, 623-644 (2002).
 	
-	\bibitem{brown1} \textsc{Brown R.}, 
-	Higher Dimensional Group Theory, Low Dimensional Topology, 
-	\emph{London Math. Soc. Lecture Note Series}, 48, 215-238, (1982).
+	\bibitem{brown-lms} \textsc{Brown, R.}, 
+	\emph{Higher Dimensional Group Theory}, 
+	in: Low Dimensional Topology, 
+	London Math. Soc. Lecture Note Series, 48, 215-238 (1982).
 	
-	%\bibitem{Spencer} \textsc{R. Brown} and \textsc{C.B. Spencer}, 
+	%\bibitem{brown-spencer} \textsc{Brown, R.} and \textsc{Spencer, C.B.}, 
 	%\textrm{G-groupoids, crossed modules and the fundamental groupoid 
 	%of topological group,} 
 	%\emph{Proc. Kon. Ned. Akad.} \textbf{79}, 296-302, (1976).
 	
-	\bibitem{rb-ng} \textsc{R. Brown} and \textsc{N.D. Gilbert}, 
-	\textrm{Algebraic models of 3--types and automorphism structures 
+	\bibitem{brown-gilbert} \textsc{Brown, R.} and \textsc{Gilbert, N.D.}, 
+	\emph{Algebraic models of $3$-types and automorphism structures 
 	for crossed modules}, 
-	\emph{Proc. London Math. Soc.} \ (3) \textbf{59}, 51-73, (1989).
+	Proc. London Math. Soc. \ (3) \textbf{59}, 51-73 (1989).
 	
-	\bibitem{bettina} \textsc{Besche H.U., Eick B. and O'Brien E.A.}, 
-	A millennium project: constructing Small Groups, 
-	\emph{\ Internat. J. Algebra Comput.}, 12, 623 - 644 (2002).
+	\bibitem{brown-loday} \textsc{Brown, R.} and \textsc{Loday, J.-L.}, 
+	\emph{Van Kampen theorems for diagram of spaces,} 
+	Topology, \textbf{26}, 311-335 (1987).
 	
 	%\bibitem{bullejos} \textsc{M.Bullejos, J.G. Cabello} and \textsc{E. Faro},
 	%\textrm{On the equivariant 2-type of a G-space}, 
@@ -1112,76 +1153,76 @@ University Scientific Research Projects (Grant No: 2017/19033).
 	%\textrm{Simplicial Crossed Modules and Mapping Cones}, 
 	%\emph{Georgian Mathematical Journal}, \textbf{10}, No.4, 623-636, (2003).
 	
-	\bibitem{Sten} \textsc{G.J. Ellis } and \textsc{R. Steiner}, 
-	\textrm{Higher dimensional crossed modules and the homotopy groups 
-	of (n+1)-ads.}, \ 
-	\emph{\ J. Pure and Applied Algebra}, \textbf{46}, 117-136, (1987).
+	\bibitem{Ellis} \textsc{Ellis, G.J.}, 
+	\emph{Crossed Squares and Combinatorial Homotopy}, 
+	Math. Z., \textbf{461}, 93-110 (1993).
 	
-	\bibitem{hap} \textsc{G.J. Ellis }, 
-	\textrm{Homological Algebra Programming}, \ 
-	{(manual for the \HAP\ package for \textsf{GAP}, version 1.19, (2019))}. 
+	\bibitem{hap} \textsc{Ellis, G.J.}, 
+	\emph{Homological Algebra Programming}, 
+	{(manual for the \HAP\ package for \textsf{GAP}, version 1.19 (2019))}. 
 
-	\bibitem{Ellis} \textsc{G.J. Ellis }, 
-	\textrm{Crossed Squares and Combinatorial Homotopy}, \ 
-	\emph{Math. Z.}, \textbf{461}, 93-110, (1993).
+	\bibitem{ellis-stenier} \textsc{Ellis, G.J.} and \textsc{Steiner, R.}, 
+	\emph{Higher dimensional crossed modules and the homotopy groups 
+	of $(n+1)$-ads.}, \ 
+	J. Pure and Applied Algebra, \textbf{46}, 117-136 (1987).
 	
-	\bibitem{Loday} \textsc{J.L. Loday}, 
-	\textrm{Spaces with finitely many non-trivial homotopy groups }, \ 
-	\emph{J. Pure and Applied Algebra}, \textbf{24}, 179-202, (1982).
+	\bibitem{gap} \textsc{The GAP Group},
+	\emph{GAP -- Groups, Algorithms, and Programming}, version 4.10.2 (2019). 
+	(https://www.gap-system.org).
 	
-	\bibitem{groupoids} \textsc{Moore E.J.} and \textsc{Wensley C.D.}, 
-	Calculations with finite groupoids and their homomorphisms 
-	{(manual for the \groupoids\ package for \textsf{GAP}, version 1.68,  
+	\bibitem{walery-loday} \textsc{Guin-Walery, D.} and \textsc{Loday, J.-L.}, 
+	\emph{Obstruction {\'{a}} l'excision en K-theories alg{\'{e}}brique}, \ 
+	in: Friedlander, E.M. and Stein, M.R. (eds.) 
+	Evanston conference on algebraic K-Theory, 1980.  
+	(Lect. Notes Math., vol.854, 179-216) 
+	Berlin Heidelberg New York : Springer (1981).
+	
+	\bibitem{Loday} \textsc{Loday, J.-L.}, 
+	\emph{Spaces with finitely many non-trivial homotopy groups}, \ 
+	J. Pure and Applied Algebra, \textbf{24}, 179-202 (1982).
+	
+	\bibitem{maclane-whitehead} 
+	\textsc{Mac Lane, S.} and \textsc{Whitehead, J.H.C.}, 
+	\emph{On the $3$-type of a complex }, 
+	Proc. Nat. Acad. Sci. U.S.A., \textbf{37}, 41-48 (1950).
+	
+	\bibitem{groupoids} \textsc{Moore, E.J.} and \textsc{Wensley, C.D.}, 
+	\emph{Calculations with finite groupoids and their homomorphisms}  
+	{(manual for the \groupoids\ package for \textsf{GAP}, version 1.68   
 	(2019))}. 
 
-	\bibitem{porter1} \textsc{Porter T.}, 
-	The Crossed Menagerie: an introduction to crossed gadgetry and cohomology 
-	in algebra and topology. 
-	\emph{Lecture Notes}, (2010).
-	
-	\bibitem{m-w} \textsc{S. Mac Lane} and \textsc{J.H.C. Whitehead}, 
-	\textrm{On the 3-type of a complex }, 
-	\emph{Proc. Nat. Acad. Sci. U.S.A.,} Vol. \textbf{\ 37}, 41-48, (1950).
-	
-	\bibitem{Mutlu} \textsc{A. Mutlu} and \textsc{T. Porter}, 
-	\textrm{Applications of Peiffer pairings in the Moore complex 
+	\bibitem{mutlu-porter-tac} \textsc{Mutlu, A.} and \textsc{Porter, T.}, 
+	\emph{Applications of Peiffer pairings in the Moore complex 
 	of a simplicial group}, 
-	\emph{Theory and Applications of Categories},  
-	Vol.4, No.\textbf{7} 148-173, (1998).
+	Theory and Applications of Categories,  
+	Vol.4, No.\textbf{7} 148-173 (1998).
 	
-	\bibitem{mutpor} \textsc{A. Mutlu} and \textsc{T. Porter}, 
-	\textrm{Crossed squares and 2-crossed modules}, 
-	\emph{Preprint}, (2003).
+	\bibitem{mutlu-porter-2003} \textsc{Mutlu, A.} and \textsc{Porter, T.}, 
+	\emph{Crossed squares and $2$-crossed modules}, 
+	preprint (2003).
 	
-	\bibitem{Porter} \textsc{T. Porter}, 
-	\textrm{n-type of simplicial groups and crossed n-cubes}, 
-	\emph{Topology ,} \textbf{32}, 5-24, (1993).
+	\bibitem{porter-topology} \textsc{Porter, T.}, 
+	\emph{$n$-type of simplicial groups and crossed $n$-cubes}, 
+	Topology, \textbf{32}, 5-24 (1993).
 	
-	\bibitem{walery} \textsc{D. Guin-Walery} and \textsc{J.L. Loday}, 
-	\textrm{Obstruction {\'{a}} l'excision en K-theories alg{\'{e}}brique, } \ 
-	\emph{In: Friedlander, E.M.,Stein, M.R.(eds.) 
-	Evanston conf. on algebraic K-Theory 1980.} 
-	(Lect. Notes Math., vol.854, pp 179-216) Berlin Heidelberg New York:Springer 
-	(1981).
+	\bibitem{porter-notes} \textsc{Porter, T.}, 
+	\emph{The Crossed Menagerie: an introduction to crossed gadgetry and cohomology 
+	in algebra and topology},  
+	\emph{Lecture Notes} (2010).
 	
-	\bibitem{wayted} \textsc{J.H.C. Whitehead}, 
-	\textrm{Combinatorial homotopy II }, 
-	\emph{Bull. Amer. Math. Soc.} \textbf{55}, 453-496, (1949).
+	\bibitem{wensley-notes} \textsc{Wensley C.D.},  
+	\emph{Notes on higher dimensional groups and related topics}, 
+	development version (2017).
 	
-	\bibitem{wensley_notes} \textsc{Wensley C.D.},  
-	Notes on higher dimensional groups and related topics, 
-	\emph{Development Version}, (2017).
-	
-	\bibitem{xmod} \textsc{Wensley C.D., Alp M., Odabas A.} and \textsc{Uslu E.O},  
-	\ Crossed modules and cat$^{1}$-groups, 
+	\bibitem{xmod} \textsc{Wensley, C.D.}, \textsc{Alp, M.}, 
+	               \textsc{Odabas, A.} and \textsc{Uslu, E.O},  
+	\emph{Crossed modules and cat$^{1}$-groups}, 
 	{(manual for the \XMod\ package for \textsf{GAP}, version 2.74 (2019))}. 
 	
+	\bibitem{whitehead-II} \textsc{J.H.C. Whitehead}, 
+	\emph{Combinatorial homotopy II }, 
+	Bull. Amer. Math. Soc., \textbf{55}, 453-496 (1949).
+	
 \end{thebibliography}
-
-
-
-
-
-
 
 \end{document}


### PR DESCRIPTION
Intro: added a list of papers not yet cited. 
2:  alpha, beta -> sigma, rho
     cat1 definition : added t^2=t, h^2=h 
3:  alpha, beta, gamma -> gamma, rho_1, rho_2 
4.2:  added oriented cat2 diagram (which needs fixing) 
5: merged cyclic groups into a single table 
    deleted C_p*C_2 case, and added rows 12/5, 20/5 and 28/4 back into the main table. 
Refs: reorganised